### PR TITLE
Updating OneAPI default values

### DIFF
--- a/oneapi/defaults/main.yaml
+++ b/oneapi/defaults/main.yaml
@@ -2,9 +2,8 @@
 
 # NSP_ONEAPI_base_toolkit_url
 NSP_ONEAPI_base_toolkit_components:
-  - "intel.oneapi.lin.dpcpp-ct"
+  - "intel.oneapi.lin.dpcpp-cpp-compiler"
   - "intel.oneapi.lin.dpcpp_dbg"
-  - "intel.oneapi.lin.dpl"
   - "intel.oneapi.lin.tbb.devel"
   - "intel.oneapi.lin.dpl"
   - "intel.oneapi.lin.dal.devel"


### PR DESCRIPTION
Updating OneAPI defaults so that the C/C++ compiler is installed in a default installation.