### PR TITLE
Add flexible naming to OneAPI role

### DIFF
--- a/oneapi/defaults/main.yaml
+++ b/oneapi/defaults/main.yaml
@@ -17,4 +17,6 @@ NSP_ONEAPI_base_toolkit_components:
 NSP_ONEAPI_hpc_toolkit_components:
   - "intel.oneapi.lin.ifort-compiler"
 
+NSP_ONEAPI_install_name: "oneapi"
 NSP_ONEAPI_create_module: true
+NSP_ONEAPI_module_name: "oneapi"

--- a/oneapi/meta/argument_specs.yaml
+++ b/oneapi/meta/argument_specs.yaml
@@ -39,8 +39,18 @@ argument_specs:
         default:
           - "intel.oneapi.lin.ifort-compiler"
         description: The HPC toolkit components to install.
+      NSP_ONEAPI_install_name:
+        type: str
+        required: false
+        default: "oneapi"
+        description: Name of the directory to install OneAPI into. Common alternatives may be "intel", or "mkl", if only MKL is installed.
       NSP_ONEAPI_create_module:
         type: bool
         required: false
         default: true
         description: Toggles module generation.
+      NSP_ONEAPI_module_name:
+        type: str
+        required: false
+        default: "oneapi"
+        description: Name of the module generated. Common names may be "oneapi", "intel", or "mkl", if only MKL is installed.

--- a/oneapi/tasks/install.yaml
+++ b/oneapi/tasks/install.yaml
@@ -47,7 +47,7 @@
       --download-cache {{ [NSP_scratch_directory, 'oneapi-{}/cache'.format(NSP_ONEAPI_version)] | path_join }}
       --download-dir {{ [NSP_scratch_directory, 'oneapi-{}/downloads'.format(NSP_ONEAPI_version)] | path_join }}
       --log-dir {{ [NSP_scratch_directory, 'oneapi-{}/logs'.format(NSP_ONEAPI_version)] | path_join }}
-      --install-dir {{ [NSP_install_root, 'oneapi', NSP_ONEAPI_version] | path_join }}
+      --install-dir {{ [NSP_install_root, NSP_ONEAPI_install_name, NSP_ONEAPI_version] | path_join }}
       --eula accept --components {{ ':'.join(NSP_ONEAPI_base_toolkit_components) }}"
   changed_when: true
   tags:
@@ -76,7 +76,7 @@
       --download-cache {{ [NSP_scratch_directory, 'oneapi-{}/cache'.format(NSP_ONEAPI_version)] | path_join }}
       --download-dir {{ [NSP_scratch_directory, 'oneapi-{}/downloads'.format(NSP_ONEAPI_version)] | path_join }}
       --log-dir {{ [NSP_scratch_directory, 'oneapi-{}/logs'.format(NSP_ONEAPI_version)] | path_join }}
-      --install-dir {{ [NSP_install_root, 'oneapi', NSP_ONEAPI_version] | path_join }}
+      --install-dir {{ [NSP_install_root, NSP_ONEAPI_install_name, NSP_ONEAPI_version] | path_join }}
       --eula accept --components {{ ':'.join(NSP_ONEAPI_hpc_toolkit_components) }}"
   changed_when: true
   tags:

--- a/oneapi/tasks/install.yaml
+++ b/oneapi/tasks/install.yaml
@@ -34,6 +34,7 @@
     owner: "{{ NSP_user }}"
     group: "{{ NSP_group }}"
     mode: "744"
+  when: NSP_ONEAPI_base_toolkit_components | length > 0
   tags:
     - oneapi
     - installation
@@ -50,6 +51,7 @@
       --install-dir {{ [NSP_install_root, NSP_ONEAPI_install_name, NSP_ONEAPI_version] | path_join }}
       --eula accept --components {{ ':'.join(NSP_ONEAPI_base_toolkit_components) }}"
   changed_when: true
+  when: NSP_ONEAPI_base_toolkit_components | length > 0
   tags:
     - oneapi
     - installation
@@ -63,6 +65,7 @@
     owner: "{{ NSP_user }}"
     group: "{{ NSP_group }}"
     mode: "744"
+  when: NSP_ONEAPI_hpc_toolkit_components | length > 0
   tags:
     - oneapi
     - installation
@@ -79,6 +82,7 @@
       --install-dir {{ [NSP_install_root, NSP_ONEAPI_install_name, NSP_ONEAPI_version] | path_join }}
       --eula accept --components {{ ':'.join(NSP_ONEAPI_hpc_toolkit_components) }}"
   changed_when: true
+  when: NSP_ONEAPI_hpc_toolkit_components | length > 0
   tags:
     - oneapi
     - installation

--- a/oneapi/tasks/main.yaml
+++ b/oneapi/tasks/main.yaml
@@ -1,14 +1,14 @@
 - name: Launch ONEAPI v{{ NSP_ONEAPI_version }} Install
   ansible.builtin.include_tasks:
     file: install.yaml
-  when: not [NSP_install_root, 'oneapi', NSP_ONEAPI_version] | path_join is directory
+  when: not [NSP_install_root, NSP_ONEAPI_install_name, NSP_ONEAPI_version] | path_join is directory
   tags:
     - oneapi
     - installation
 
 - name: Create ONEAPI Module Directory
   ansible.builtin.file:
-    path: "{{ [NSP_module_root, 'oneapi'] | path_join }}"
+    path: "{{ [NSP_module_root, NSP_ONEAPI_module_name] | path_join }}"
     state: directory
     owner: "{{ NSP_user }}"
     group: "{{ NSP_group }}"
@@ -21,7 +21,7 @@
 - name: Generate ONEAPI v{{ NSP_ONEAPI_version }} Module File
   ansible.builtin.template:
     src: module.lua.j2
-    dest: "{{ [NSP_module_root, 'oneapi', '{}.lua'.format(NSP_ONEAPI_version)] | path_join }}"
+    dest: "{{ [NSP_module_root, NSP_ONEAPI_module_name, '{}.lua'.format(NSP_ONEAPI_version)] | path_join }}"
     owner: "{{ NSP_user }}"
     group: "{{ NSP_group }}"
     mode: "{{ NSP_file_permissions }}"

--- a/oneapi/templates/module.lua.j2
+++ b/oneapi/templates/module.lua.j2
@@ -1,19 +1,32 @@
 {{ ansible_managed | comment(beginning="--[[", end="]]--", decoration="", prefix_count=0, postfix_count=0) }}
 
+{% if "intel.oneapi.lin.dpcpp-cpp-compiler" in NSP_ONEAPI_base_toolkit_components or "intel.oneapi.lin.ifort-compiler" in NSP_ONEAPI_hpc_toolkit_components %}
 family("compiler")
+{% endif %}
 
 whatis("Intel OneAPI v{{ NSP_ONEAPI_version }}")
 
-help("Intel OneAPI v{{ NSP_ONEAPI_version }}")
+help("Intel OneAPI v{{ NSP_ONEAPI_version }} Suite, with the following components installed:
+{% for c in NSP_ONEAPI_base_toolkit_components %}
+{{ c }}
+{% endfor %}
+{% for c in NSP_ONEAPI_hpc_toolkit_components %}
+{{ c }}
+{% endfor %}
+")
 
 local base = "{{ NSP_install_root }}"
-local package = "oneapi"
+local package = "{{ NSP_ONEAPI_install_name }}"
 local version = "{{ NSP_ONEAPI_version }}"
 local prefix = pathJoin(base, package, version, "{{ '.'.join(NSP_ONEAPI_version.split('.')[:2]) }}")
 
 setenv("INTEL_PATH", prefix)
 setenv("INTEL_VERSION", version)
+
+{% if "intel.oneapi.lin.dpcpp-cpp-compiler" in NSP_ONEAPI_base_toolkit_components or "intel.oneapi.lin.ifort-compiler" in NSP_ONEAPI_hpc_toolkit_components %}
 setenv("INTEL_COMPILER_TYPE", "ONEAPI")
+{% endif %}
+
 prepend_path("PATH",  pathJoin(prefix, "bin" ))
 prepend_path("MANPATH", pathJoin(prefix, "share/man" ))
 prepend_path("LD_LIBRARY_PATH", pathJoin(prefix, "lib"))


### PR DESCRIPTION
With this commit, you can specify `NSP_ONEAPI_module_name` to change the name of the module that's generated (ie, if you only install MKL, name it `mkl`), and `NSP_ONEAPI_install_name`, which changes the name of the directory in the install root where this is installed. For example, so that you can install the complete OneAPI kit, then install MKL independently. Without the ability to change that install name, they will install to the same directory.