### PR TITLE
Adding aws-ofi-nccl/aws-ofi-rccl role

### DIFF
--- a/aws-ofi-nccl/defaults/main.yaml
+++ b/aws-ofi-nccl/defaults/main.yaml
@@ -1,10 +1,10 @@
 
-NSP_OFI_NCCL_libfabric_root: "/opt/cray/libfabric/2.3.1"
-NSP_OFI_NCCL_gpu_modules:
-  rocm/6.4.2: "/opt/rocm-6.4.2"
-  rocm/7.1.1: "/opt/rocm-7.1.1"
-NSP_OFI_NCCL_install_name: "rccl-plugins/aws-ofi-nccl"
-NSP_OFI_NCCL_version: "1.19.2"
-NSP_OFI_NCCL_module_name: "rccl-net-plugin"
-NSP_OFI_NCCL_module_version: "1.0"
-NSP_OFI_NCCL_gpu_vendor: "amd"
+# NSP_OFI_NCCL_libfabric_root: "/opt/cray/libfabric/2.3.1"
+# NSP_OFI_NCCL_gpu_modules:
+#  rocm/6.4.2: "/opt/rocm-6.4.2"
+#  rocm/7.1.1: "/opt/rocm-7.1.1"
+# NSP_OFI_NCCL_install_name: "rccl-plugins/aws-ofi-nccl"
+# NSP_OFI_NCCL_version: "1.19.2"
+# NSP_OFI_NCCL_module_name: "rccl-net-plugin"
+# NSP_OFI_NCCL_module_version: "1.0"
+# NSP_OFI_NCCL_gpu_vendor: "amd"

--- a/aws-ofi-nccl/defaults/main.yaml
+++ b/aws-ofi-nccl/defaults/main.yaml
@@ -1,0 +1,10 @@
+
+NSP_OFI_NCCL_libfabric_root: "/opt/cray/libfabric/2.3.1"
+NSP_OFI_NCCL_gpu_modules:
+  rocm/6.4.2: "/opt/rocm-6.4.2"
+  rocm/7.1.1: "/opt/rocm-7.1.1"
+NSP_OFI_NCCL_install_name: "rccl-plugins/aws-ofi-nccl"
+NSP_OFI_NCCL_version: "1.19.2"
+NSP_OFI_NCCL_module_name: "rccl-net-plugin"
+NSP_OFI_NCCL_module_version: "1.0"
+NSP_OFI_NCCL_gpu_vendor: "amd"

--- a/aws-ofi-nccl/meta/argument_specs.yaml
+++ b/aws-ofi-nccl/meta/argument_specs.yaml
@@ -1,0 +1,37 @@
+argument_specs:
+  main:
+    description:
+      - Installs AWS's NCCL/RCCL bindings for the Open Fabrics Interface (aws-ofi-nccl)
+    options:
+      NSP_OFI_NCCL_version:
+        type: str
+        required: true
+        description: The version of aws-ofi-nccl to install.
+      NSP_OFI_NCCL_module_name:
+        type: str
+        required: true
+        description: The name of the resulting module. Common names may be "aws-ofi-rccl" or "rccl-net-plugin"
+      NSP_OFI_NCCL_module_version:
+        type: str
+        required: true
+        description: The version of the resulting module.
+      NSP_OFI_NCCL_libfabric_root:
+        type: str
+        required: true
+        description: The version of the libfabric installation to use for compilation.
+      NSP_OFI_NCCL_gpu_modules:
+        type: dict
+        required: true
+        description: The list of versions of the ROCm or CUDA-providing module to use for compilation.
+      NSP_OFI_NCCL_help_msg:
+        type: str
+        required: false
+        description: An extension to the default help message for the module.
+      NSP_OFI_NCCL_gpu_vendor:
+        type: str
+        required: false
+        description: "The name of the GPU vendor, 'amd' or 'nvidia'."
+      NSP_OFI_NCCL_extra_envvars:
+        type: dict
+        required: true
+        description: A list of key-value environment variable pairs to set in the resulting modulefile.

--- a/aws-ofi-nccl/meta/argument_specs.yaml
+++ b/aws-ofi-nccl/meta/argument_specs.yaml
@@ -29,9 +29,9 @@ argument_specs:
         description: An extension to the default help message for the module.
       NSP_OFI_NCCL_gpu_vendor:
         type: str
-        required: false
+        required: true
         description: "The name of the GPU vendor, 'amd' or 'nvidia'."
       NSP_OFI_NCCL_extra_envvars:
         type: dict
-        required: true
+        required: false
         description: A list of key-value environment variable pairs to set in the resulting modulefile.

--- a/aws-ofi-nccl/meta/main.yaml
+++ b/aws-ofi-nccl/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - nsp

--- a/aws-ofi-nccl/tasks/install.yaml
+++ b/aws-ofi-nccl/tasks/install.yaml
@@ -1,0 +1,67 @@
+- name: Clear Previous OFI_NCCL v{{ NSP_OFI_NCCL_version }} Files
+  ansible.builtin.file:
+    path: "{{ [NSP_scratch_directory, 'aws-ofi-nccl-{}'.format(NSP_OFI_NCCL_version)] | path_join }}"
+    state: absent
+  tags:
+    - ofi-nccl
+
+- name: Create Scratch Subdirectory for OFI_NCCL v{{ NSP_OFI_NCCL_version }}
+  ansible.builtin.file:
+    path: "{{ [NSP_scratch_directory, 'aws-ofi-nccl-{}'.format(NSP_OFI_NCCL_version)] | path_join }}"
+    state: directory
+    owner: "{{ NSP_user }}"
+    group: "{{ NSP_group }}"
+    mode: "{{ NSP_executable_permissions }}"
+  tags:
+    - ofi-nccl
+
+- name: Download OFI_NCCL v{{ NSP_OFI_NCCL_version }}
+  ansible.builtin.unarchive:
+    remote_src: true
+    src: "https://github.com/aws/aws-ofi-nccl/releases/download/v{{ NSP_OFI_NCCL_version }}/aws-ofi-nccl-{{ NSP_OFI_NCCL_version }}.tar.gz"
+    dest: "{{ NSP_scratch_directory }}"
+    group: "{{ NSP_group }}"
+    owner: "{{ NSP_user }}"
+    mode: "{{ NSP_executable_permissions }}"
+  tags:
+    - ofi-nccl
+
+- name: Install OFI_NCCL v{{ NSP_OFI_NCCL_version }} for {{ gpu_module }}
+  ansible.builtin.shell:
+    cmd: |
+      cd {{ [NSP_scratch_directory, 'aws-ofi-nccl-{}'.format(NSP_OFI_NCCL_version)] | path_join }}
+      ./autogen.sh
+      ./configure \
+        --with-rocm={{ gpu_install_path }} \
+        --with-libfabric={{ NSP_OFI_NCCL_libfabric_root }} \
+        --prefix={{ [NSP_install_root, NSP_OFI_NCCL_install_name, NSP_OFI_NCCL_version, gpu_module] | path_join }}
+      make install
+      cd {{ [NSP_install_root, NSP_OFI_NCCL_install_name, NSP_OFI_NCCL_version, gpu_module, 'lib'] | path_join }}
+      ln -s librccl-net.so libnccl-net.so
+  changed_when: true
+  when: NSP_OFI_NCCL_gpu_vendor == "amd"
+  tags:
+    - ofi-nccl
+
+- name: Install OFI_NCCL v{{ NSP_OFI_NCCL_version }} for {{ gpu_module }}
+  ansible.builtin.shell:
+    cmd: |
+      cd {{ [NSP_scratch_directory, 'aws-ofi-nccl-{}'.format(NSP_OFI_NCCL_version)] | path_join }}
+      ./autogen.sh
+      ./configure
+        --with-cuda={{ gpu_install_path }} \
+        --with-libfabric={{ NSP_OFI_NCCL_libfabric_root }} \
+        --prefix={{ [NSP_install_root, NSP_OFI_NCCL_install_name, NSP_OFI_NCCL_version, gpu_module] | path_join }}"
+      make install
+  changed_when: true
+  when: NSP_OFI_NCCL_gpu_vendor == "nvidia"
+  tags:
+    - ofi-nccl
+
+- name: Clean Up Scratch After OFI_NCCL v{{ NSP_OFI_NCCL_version }} Build
+  ansible.builtin.include_role:
+    name: nsp
+    tasks_from: clear_scratch
+  when: NSP_keep_scratch_clear
+  tags:
+    - ofi-nccl

--- a/aws-ofi-nccl/tasks/install.yaml
+++ b/aws-ofi-nccl/tasks/install.yaml
@@ -3,7 +3,7 @@
     path: "{{ [NSP_scratch_directory, 'aws-ofi-nccl-{}'.format(NSP_OFI_NCCL_version)] | path_join }}"
     state: absent
   tags:
-    - ofi-nccl
+    - aws-ofi-nccl
 
 - name: Create Scratch Subdirectory for OFI_NCCL v{{ NSP_OFI_NCCL_version }}
   ansible.builtin.file:
@@ -13,7 +13,7 @@
     group: "{{ NSP_group }}"
     mode: "{{ NSP_executable_permissions }}"
   tags:
-    - ofi-nccl
+    - aws-ofi-nccl
 
 - name: Download OFI_NCCL v{{ NSP_OFI_NCCL_version }}
   ansible.builtin.unarchive:
@@ -24,7 +24,7 @@
     owner: "{{ NSP_user }}"
     mode: "{{ NSP_executable_permissions }}"
   tags:
-    - ofi-nccl
+    - aws-ofi-nccl
 
 - name: Install OFI_NCCL v{{ NSP_OFI_NCCL_version }} for {{ gpu_module }}
   ansible.builtin.shell:
@@ -41,7 +41,7 @@
   changed_when: true
   when: NSP_OFI_NCCL_gpu_vendor == "amd"
   tags:
-    - ofi-nccl
+    - aws-ofi-nccl
 
 - name: Install OFI_NCCL v{{ NSP_OFI_NCCL_version }} for {{ gpu_module }}
   ansible.builtin.shell:
@@ -56,7 +56,7 @@
   changed_when: true
   when: NSP_OFI_NCCL_gpu_vendor == "nvidia"
   tags:
-    - ofi-nccl
+    - aws-ofi-nccl
 
 - name: Clean Up Scratch After OFI_NCCL v{{ NSP_OFI_NCCL_version }} Build
   ansible.builtin.include_role:
@@ -64,4 +64,4 @@
     tasks_from: clear_scratch
   when: NSP_keep_scratch_clear
   tags:
-    - ofi-nccl
+    - aws-ofi-nccl

--- a/aws-ofi-nccl/tasks/main.yaml
+++ b/aws-ofi-nccl/tasks/main.yaml
@@ -3,6 +3,8 @@
     path: "{{ [NSP_install_root, NSP_OFI_NCCL_install_name, NSP_OFI_NCCL_version, item.key] | path_join }}"
   loop: "{{ NSP_OFI_NCCL_gpu_modules | dict2items }}"
   register: path_check
+  tags:
+    - aws-ofi-nccl
 
 - name: Launch OFI_NCCL v{{ NSP_OFI_NCCL_version }} Install
   ansible.builtin.include_tasks:
@@ -13,7 +15,7 @@
   loop: "{{ path_check.results }}"
   when: not item.stat.exists
   tags:
-    - ofi-nccl
+    - aws-ofi-nccl
 
 - name: Create OFI_NCCL Module Directory
   ansible.builtin.file:
@@ -23,7 +25,7 @@
     group: "{{ NSP_group }}"
     mode: "{{ NSP_executable_permissions }}"
   tags:
-    - ofi-nccl
+    - aws-ofi-nccl
 
 - name: Generate OFI_NCCL v{{ NSP_OFI_NCCL_version }} Module File
   ansible.builtin.template:
@@ -33,4 +35,4 @@
     group: "{{ NSP_group }}"
     mode: "{{ NSP_file_permissions }}"
   tags:
-    - ofi-nccl
+    - aws-ofi-nccl

--- a/aws-ofi-nccl/tasks/main.yaml
+++ b/aws-ofi-nccl/tasks/main.yaml
@@ -1,0 +1,36 @@
+- name: Check OFI_NCCL if the installation root exists for each GPU library version
+  ansible.builtin.stat:
+    path: "{{ [NSP_install_root, NSP_OFI_NCCL_install_name, NSP_OFI_NCCL_version, item.key] | path_join }}"
+  loop: "{{ NSP_OFI_NCCL_gpu_modules | dict2items }}"
+  register: path_check
+
+- name: Launch OFI_NCCL v{{ NSP_OFI_NCCL_version }} Install
+  ansible.builtin.include_tasks:
+    file: install.yaml
+  vars:
+    gpu_install_path: "{{ item.item.value }}"
+    gpu_module: "{{ item.item.key }}"
+  loop: "{{ path_check.results }}"
+  when: not item.stat.exists
+  tags:
+    - ofi-nccl
+
+- name: Create OFI_NCCL Module Directory
+  ansible.builtin.file:
+    path: "{{ [NSP_module_root, NSP_OFI_NCCL_module_name] | path_join }}"
+    state: directory
+    owner: "{{ NSP_user }}"
+    group: "{{ NSP_group }}"
+    mode: "{{ NSP_executable_permissions }}"
+  tags:
+    - ofi-nccl
+
+- name: Generate OFI_NCCL v{{ NSP_OFI_NCCL_version }} Module File
+  ansible.builtin.template:
+    src: module.lua.j2
+    dest: "{{ [NSP_module_root, NSP_OFI_NCCL_module_name, '{}.lua'.format(NSP_OFI_NCCL_module_version)] | path_join }}"
+    owner: "{{ NSP_user }}"
+    group: "{{ NSP_group }}"
+    mode: "{{ NSP_file_permissions }}"
+  tags:
+    - ofi-nccl

--- a/aws-ofi-nccl/templates/module.lua.j2
+++ b/aws-ofi-nccl/templates/module.lua.j2
@@ -1,0 +1,41 @@
+{{ ansible_managed | comment(beginning='--[[', end=']]--', decoration='', prefix_count=0, postfix_count=0) }}
+
+whatis("AWS NCCL/RCCL OFI interfaces, version {{ NSP_OFI_NCCL_version }}")
+
+help([[AWS NCCL/RCCL OFI v{{ NSP_OFI_NCCL_version }}, required for running RCCL/NCCL on Slingshot interconnects.
+This plugin was installed for the following GPU SDK versions:
+{% for m in NSP_OFI_NCCL_gpu_modules %}
+- {{ m }}
+{% endfor %}
+{{ NSP_OFI_NCCL_help_msg }}
+]])
+
+local base = "{{ NSP_install_root }}"
+local package = "{{ NSP_OFI_NCCL_install_name }}"
+local version = "{{ NSP_OFI_NCCL_version }}"
+local prefix = pathJoin(base, package, version)
+
+-- Always require ROCm to be loaded
+prereq_any({{ NSP_OFI_NCCL_gpu_modules.keys() | map('tojson') | join(',') }})
+
+if ("1" == "0") then
+    LmodError("A dummy error message to enable using elseif's for GPU-enabling module versions.")
+{% for m in NSP_OFI_NCCL_gpu_modules %}
+elseif isloaded("{{ m }}") then
+    gpu_module = "{{ m }}"
+{% endfor %}
+end
+
+local plugin_install_dir = pathJoin(prefix, gpu_module)
+
+if (not isDir(plugin_install_dir)) then
+	LmodError("Could not find the rccl-net-plugin install for ",gpu_module,". Please submit a ticket to help@olcf.ornl.gov to report this error. Please include which ROCm/CUDA version you are trying to load this module for.")
+end
+
+prepend_path("LD_LIBRARY_PATH", pathJoin(plugin_install_dir, 'lib'))
+
+{% for k, v in NSP_OFI_NCCL_extra_envvars.items() %}
+setenv("{{ k }}", "{{ v }}")
+{% endfor %}
+
+setenv(string.upper("{{ NSP_site_name }}_") .. "OFI_NCCL_ROOT",  plugin_install_dir)


### PR DESCRIPTION
Adds an aws-ofi-nccl role, which will be used to provision the `rccl-net-plugin` module on Frontier.