### PR TITLE
Added the ability to install OneAPI v2026

### DIFF
--- a/miniforge3/tasks/main.yaml
+++ b/miniforge3/tasks/main.yaml
@@ -52,8 +52,9 @@
   ansible.builtin.shell:  # noqa risky-shell-pipe
     cmd: "export PATH={{ [NSP_install_root, 'miniforge3',
       '{}-{}'.format(NSP_MINIFORGE3_version, NSP_MINIFORGE3_revision), 'bin'] | path_join }}:$PATH\n
-      source deactivate\n
-      conda list | awk 'NR > 3 {print $1}' | grep -E
+      conda list -p {{ [NSP_install_root, 'miniforge3',
+      '{}-{}'.format(NSP_MINIFORGE3_version, NSP_MINIFORGE3_revision)] | path_join }} |
+      awk 'NR > 3 {print $1}' | grep -E
       '^({% for package in NSP_MINIFORGE3_base_packages %}{{ package }}|{% endfor %})$' | wc -l"
   register: base_package_num
   changed_when: (NSP_MINIFORGE3_base_packages | list | length) != (base_package_num.stdout | int)
@@ -64,8 +65,8 @@
   ansible.builtin.shell:
     cmd: "export PATH={{ [NSP_install_root, 'miniforge3', '{}-{}'.format(NSP_MINIFORGE3_version,
       NSP_MINIFORGE3_revision), 'bin'] | path_join }}:$PATH\n
-      source deactivate\n
-      conda install -y{% for package in NSP_MINIFORGE3_base_packages %} {{ package }}{% endfor %}"
+      conda install -y -p {{ [NSP_install_root, 'miniforge3',
+      '{}-{}'.format(NSP_MINIFORGE3_version, NSP_MINIFORGE3_revision)] | path_join }}{% for package in NSP_MINIFORGE3_base_packages %} {{ package }}{% endfor %}"
   when: (NSP_MINIFORGE3_base_packages | list | length) != (base_package_num.stdout | int)
   changed_when: true
   tags:

--- a/oneapi/defaults/main.yaml
+++ b/oneapi/defaults/main.yaml
@@ -17,6 +17,18 @@ NSP_ONEAPI_base_toolkit_components:
 NSP_ONEAPI_hpc_toolkit_components:
   - "intel.oneapi.lin.ifort-compiler"
 
+NSP_ONEAPI_toolkit_components:
+  - "intel.oneapi.lin.dpcpp-cpp-compiler"
+  - "intel.oneapi.lin.dpl"
+  - "intel.oneapi.lin.dpcpp_dbg"
+  - "intel.oneapi.lin.ifort-compiler"
+  - "intel.oneapi.lin.mpi.devel"
+  - "intel.oneapi.lin.tbb.devel"
+  - "intel.oneapi.lin.ipp.devel"
+  - "intel.oneapi.lin.ippcp.devel"
+  - "intel.oneapi.lin.mkl.devel"
+  - "intel.oneapi.lin.vtune"
+
 NSP_ONEAPI_install_name: "oneapi"
 NSP_ONEAPI_create_module: true
 NSP_ONEAPI_module_name: "oneapi"

--- a/oneapi/meta/argument_specs.yaml
+++ b/oneapi/meta/argument_specs.yaml
@@ -9,7 +9,7 @@ argument_specs:
         description: The version to install.
       NSP_ONEAPI_base_toolkit_url:
         type: str
-        required: true
+        required: false
         description: The download URL for the base toolkit installer.
       NSP_ONEAPI_base_toolkit_components:
         type: list
@@ -30,7 +30,7 @@ argument_specs:
         description: The base toolkit components to install.
       NSP_ONEAPI_hpc_toolkit_url:
         type: str
-        required: true
+        required: false
         description: The download URL for the HPC toolkit installer.
       NSP_ONEAPI_hpc_toolkit_components:
         type: list
@@ -39,6 +39,28 @@ argument_specs:
         default:
           - "intel.oneapi.lin.ifort-compiler"
         description: The HPC toolkit components to install.
+      NSP_ONEAPI_toolkit_url:
+        type: str
+        required: false
+        description: The download URL for the OneAPI toolkit installer.
+      NSP_ONEAPI_toolkit_components:
+        type: list
+        elements: str
+        required: false
+        default:
+          - "intel.oneapi.lin.dpcpp-ct"
+          - "intel.oneapi.lin.dpcpp_dbg"
+          - "intel.oneapi.lin.dpl"
+          - "intel.oneapi.lin.tbb.devel"
+          - "intel.oneapi.lin.dpl"
+          - "intel.oneapi.lin.dal.devel"
+          - "intel.oneapi.lin.ipp.devel"
+          - "intel.oneapi.lin.ippcp.devel"
+          - "intel.oneapi.lin.mkl.devel"
+          - "intel.oneapi.lin.advisor"
+          - "intel.oneapi.lin.vtune"
+          - "intel.oneapi.lin.ifort-compiler"
+        description: The OneAPI toolkit components to install.
       NSP_ONEAPI_install_name:
         type: str
         required: false

--- a/oneapi/tasks/install.yaml
+++ b/oneapi/tasks/install.yaml
@@ -23,61 +23,95 @@
     - oneapi
 
 # Base Toolkit
-- name: Download ONEAPI v{{ NSP_ONEAPI_version }} Base Toolkit
-  ansible.builtin.get_url:
-    url: "{{ NSP_ONEAPI_base_toolkit_url }}"
-    dest: "{{ [NSP_scratch_directory, 'oneapi-{}'.format(NSP_ONEAPI_version)] | path_join }}/"
-    owner: "{{ NSP_user }}"
-    group: "{{ NSP_group }}"
-    mode: "744"
-  when: NSP_ONEAPI_base_toolkit_components | length > 0
-  tags:
-    - oneapi
-
-- name: Install ONEAPI v{{ NSP_ONEAPI_version }} Base Toolkit
-  ansible.builtin.command:
-    cmd: "{{
-      [NSP_scratch_directory, 'oneapi-{}'.format(NSP_ONEAPI_version), NSP_ONEAPI_base_toolkit_url.split('/')[-1]]
-      | path_join }}
-      --remove-extracted-files yes -a --cli --silent --action install
-      --download-cache {{ [NSP_scratch_directory, 'oneapi-{}/cache'.format(NSP_ONEAPI_version)] | path_join }}
-      --download-dir {{ [NSP_scratch_directory, 'oneapi-{}/downloads'.format(NSP_ONEAPI_version)] | path_join }}
-      --log-dir {{ [NSP_scratch_directory, 'oneapi-{}/logs'.format(NSP_ONEAPI_version)] | path_join }}
-      --install-dir {{ [NSP_install_root, NSP_ONEAPI_install_name, NSP_ONEAPI_version] | path_join }}
-      --eula accept --components {{ ':'.join(NSP_ONEAPI_base_toolkit_components) }}"
-  changed_when: true
-  when: NSP_ONEAPI_base_toolkit_components | length > 0
-  tags:
-    - oneapi
+- block:
+  - name: Download ONEAPI v{{ NSP_ONEAPI_version }} Base Toolkit
+    ansible.builtin.get_url:
+      url: "{{ NSP_ONEAPI_base_toolkit_url }}"
+      dest: "{{ [NSP_scratch_directory, 'oneapi-{}'.format(NSP_ONEAPI_version)] | path_join }}/"
+      owner: "{{ NSP_user }}"
+      group: "{{ NSP_group }}"
+      mode: "744"
+    when: NSP_ONEAPI_base_toolkit_components | length > 0
+    tags:
+      - oneapi
+  
+  - name: Install ONEAPI v{{ NSP_ONEAPI_version }} Base Toolkit
+    ansible.builtin.command:
+      cmd: "{{
+        [NSP_scratch_directory, 'oneapi-{}'.format(NSP_ONEAPI_version), NSP_ONEAPI_base_toolkit_url.split('/')[-1]]
+        | path_join }}
+        --remove-extracted-files yes -a --cli --silent --action install
+        --download-cache {{ [NSP_scratch_directory, 'oneapi-{}/cache'.format(NSP_ONEAPI_version)] | path_join }}
+        --download-dir {{ [NSP_scratch_directory, 'oneapi-{}/downloads'.format(NSP_ONEAPI_version)] | path_join }}
+        --log-dir {{ [NSP_scratch_directory, 'oneapi-{}/logs'.format(NSP_ONEAPI_version)] | path_join }}
+        --install-dir {{ [NSP_install_root, NSP_ONEAPI_install_name, NSP_ONEAPI_version] | path_join }}
+        --eula accept --components {{ ':'.join(NSP_ONEAPI_base_toolkit_components) }}"
+    changed_when: true
+    when: NSP_ONEAPI_base_toolkit_components | length > 0
+    tags:
+      - oneapi
+  ###
+  
+  # HPC Toolkit
+  - name: Download ONEAPI v{{ NSP_ONEAPI_version }} HPC Toolkit
+    ansible.builtin.get_url:
+      url: "{{ NSP_ONEAPI_hpc_toolkit_url }}"
+      dest: "{{ [NSP_scratch_directory, 'oneapi-{}'.format(NSP_ONEAPI_version)] | path_join }}"
+      owner: "{{ NSP_user }}"
+      group: "{{ NSP_group }}"
+      mode: "744"
+    when: NSP_ONEAPI_hpc_toolkit_components | length > 0
+    tags:
+      - oneapi
+  
+  - name: Install ONEAPI v{{ NSP_ONEAPI_version }} HPC Toolkit
+    ansible.builtin.command:
+      cmd: "{{
+        [NSP_scratch_directory, 'oneapi-{}'.format(NSP_ONEAPI_version), NSP_ONEAPI_hpc_toolkit_url.split('/')[-1]]
+        | path_join }}
+        --remove-extracted-files yes -a --cli --silent --action install
+        --download-cache {{ [NSP_scratch_directory, 'oneapi-{}/cache'.format(NSP_ONEAPI_version)] | path_join }}
+        --download-dir {{ [NSP_scratch_directory, 'oneapi-{}/downloads'.format(NSP_ONEAPI_version)] | path_join }}
+        --log-dir {{ [NSP_scratch_directory, 'oneapi-{}/logs'.format(NSP_ONEAPI_version)] | path_join }}
+        --install-dir {{ [NSP_install_root, NSP_ONEAPI_install_name, NSP_ONEAPI_version] | path_join }}
+        --eula accept --components {{ ':'.join(NSP_ONEAPI_hpc_toolkit_components) }}"
+    changed_when: true
+    when: NSP_ONEAPI_hpc_toolkit_components | length > 0
+    tags:
+      - oneapi
+  when: NSP_ONEAPI_version < '2026.0.0'  
 ###
 
-# HPC Toolkit
-- name: Download ONEAPI v{{ NSP_ONEAPI_version }} HPC Toolkit
-  ansible.builtin.get_url:
-    url: "{{ NSP_ONEAPI_hpc_toolkit_url }}"
-    dest: "{{ [NSP_scratch_directory, 'oneapi-{}'.format(NSP_ONEAPI_version)] | path_join }}"
-    owner: "{{ NSP_user }}"
-    group: "{{ NSP_group }}"
-    mode: "744"
-  when: NSP_ONEAPI_hpc_toolkit_components | length > 0
-  tags:
-    - oneapi
-
-- name: Install ONEAPI v{{ NSP_ONEAPI_version }} HPC Toolkit
-  ansible.builtin.command:
-    cmd: "{{
-      [NSP_scratch_directory, 'oneapi-{}'.format(NSP_ONEAPI_version), NSP_ONEAPI_hpc_toolkit_url.split('/')[-1]]
-      | path_join }}
-      --remove-extracted-files yes -a --cli --silent --action install
-      --download-cache {{ [NSP_scratch_directory, 'oneapi-{}/cache'.format(NSP_ONEAPI_version)] | path_join }}
-      --download-dir {{ [NSP_scratch_directory, 'oneapi-{}/downloads'.format(NSP_ONEAPI_version)] | path_join }}
-      --log-dir {{ [NSP_scratch_directory, 'oneapi-{}/logs'.format(NSP_ONEAPI_version)] | path_join }}
-      --install-dir {{ [NSP_install_root, NSP_ONEAPI_install_name, NSP_ONEAPI_version] | path_join }}
-      --eula accept --components {{ ':'.join(NSP_ONEAPI_hpc_toolkit_components) }}"
-  changed_when: true
-  when: NSP_ONEAPI_hpc_toolkit_components | length > 0
-  tags:
-    - oneapi
+# VERSION 2026 ONWARD - combined base and hpc toolkits
+- block:
+  - name: Download ONEAPI v{{ NSP_ONEAPI_version }} Toolkit
+    ansible.builtin.get_url:
+      url: "{{ NSP_ONEAPI_toolkit_url }}"
+      dest: "{{ [NSP_scratch_directory, 'oneapi-{}'.format(NSP_ONEAPI_version)] | path_join }}"
+      owner: "{{ NSP_user }}"
+      group: "{{ NSP_group }}"
+      mode: "744"
+      validate_certs: no
+    when: NSP_ONEAPI_toolkit_components | length > 0
+    tags:
+      - oneapi
+  
+  - name: Install ONEAPI v{{ NSP_ONEAPI_version }} Toolkit
+    ansible.builtin.command:
+      cmd: "{{
+        [NSP_scratch_directory, 'oneapi-{}'.format(NSP_ONEAPI_version), NSP_ONEAPI_toolkit_url.split('/')[-1]]
+        | path_join }}
+        --remove-extracted-files yes -a --cli --silent --action install
+        --download-cache {{ [NSP_scratch_directory, 'oneapi-{}/cache'.format(NSP_ONEAPI_version)] | path_join }}
+        --download-dir {{ [NSP_scratch_directory, 'oneapi-{}/downloads'.format(NSP_ONEAPI_version)] | path_join }}
+        --log-dir {{ [NSP_scratch_directory, 'oneapi-{}/logs'.format(NSP_ONEAPI_version)] | path_join }}
+        --install-dir {{ [NSP_install_root, NSP_ONEAPI_install_name, NSP_ONEAPI_version] | path_join }}
+        --eula accept --components {{ ':'.join(NSP_ONEAPI_toolkit_components) }}"
+    changed_when: true
+    when: NSP_ONEAPI_toolkit_components | length > 0
+    tags:
+      - oneapi
+  when: NSP_ONEAPI_version >= '2026.0.0'
 ###
 
 - name: Delete 'intel' Directory in Home


### PR DESCRIPTION
OneAPI Toolkit v2026.0.0 and onward have unified the Base and HPC toolkits into one toolkit. I have added the option to install the unified toolkit in the oneapi role. The role now checks the version number of the requested oneapi install and proceeds accordingly by using 2 urls for <2026 and 1 url for >=2026.